### PR TITLE
Externalize Firebase config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Node or environment-specific files
+config/firebase-config.js
+.env

--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 # RelaisCSE
+
+## Configuration Firebase
+
+Les valeurs de `firebaseConfig` sont maintenant stockées dans un fichier non versionné.
+
+1. Copier `config/firebase-config.example.js` vers `config/firebase-config.js`.
+2. Remplir ce nouveau fichier avec vos informations Firebase.
+3. S'assurer qu'il reste exclu du contrôle de version (voir `.gitignore`).
+

--- a/config/firebase-config.example.js
+++ b/config/firebase-config.example.js
@@ -1,0 +1,11 @@
+// Exemple de configuration Firebase. Copiez ce fichier en
+// config/firebase-config.js et remplissez avec vos valeurs.
+export const firebaseConfig = {
+  apiKey: "VOTRE_API_KEY",
+  authDomain: "VOTRE_AUTH_DOMAIN",
+  projectId: "VOTRE_PROJECT_ID",
+  storageBucket: "VOTRE_STORAGE_BUCKET",
+  messagingSenderId: "VOTRE_MESSAGING_SENDER_ID",
+  appId: "VOTRE_APP_ID",
+  measurementId: "VOTRE_MEASUREMENT_ID"
+};

--- a/js/firebase-config.js
+++ b/js/firebase-config.js
@@ -4,16 +4,8 @@ import { getAuth } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-aut
 import { getFirestore } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore.js";
 // Si vous utilisez Storage plus tard : import { getStorage } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-storage.js";
 
-// Votre configuration Firebase personnelle (NE PAS PARTAGER LA CLÉ BRUTE PUBLIQUEMENT)
-const firebaseConfig = {
-  apiKey: "AIzaSyCAyHUsKhQ9HdUQkizEKEsn37rOUmHuqrk", // VOTRE CLÉ API (gardez-la secrète idéalement via variables d'env. pour projet pro)
-  authDomain: "vinted-entreprise.firebaseapp.com",
-  projectId: "vinted-entreprise",
-  storageBucket: "vinted-entreprise.appspot.com", // Vérifiez ce nom dans votre console Firebase (généralement sans firebase)
-  messagingSenderId: "301194568056",
-  appId: "1:301194568056:web:ef6da7eb1c0795e2eae88d",
-  measurementId: "G-EEGS88XHHB" // Optionnel pour Analytics
-};
+// Configuration Firebase chargée depuis un fichier non versionné
+import { firebaseConfig } from '../config/firebase-config.js';
 
 // Initialiser Firebase
 const app = initializeApp(firebaseConfig);


### PR DESCRIPTION
## Summary
- read firebase credentials from a non versioned file
- provide example config and ignore real credentials
- document how to set up the config

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684dc8a80b288332bae68d7d1060f5eb