### PR TITLE
Remove duplicate IDs and cleanup

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
     <img src="img/LogoRelaisCSE3.png" alt="Logo RelaisCSE" class="login-logo">
     <h1 class="login-title">Bienvenue sur Le Relais du CSE</h1>
     <p class="login-subtitle">Seconde Main, Premier Lien</p>
-    <button id="google-signin-button" class="btn-login-google">
+    <button id="google-signin-button-login" class="btn-login-google">
       <i class="fab fa-google"></i> Connexion avec Google
     </button>
     <p id="login-error" class="login-error" style="display:none;"></p>
@@ -59,7 +59,7 @@
             </ul>
             <!-- Conteneur pour la connexion/déconnexion dynamique -->
             <div id="auth-container">
-                <button id="google-signin-button" class="btn btn-primary">Connexion avec Google</button>
+                <button id="google-signin-button-header" class="btn btn-primary">Connexion avec Google</button>
                 <!-- Ou les infos utilisateur si connecté -->
             </div>
         </nav>
@@ -183,10 +183,10 @@
             <label for="relais-image">Image (JPEG, PNG, GIF) *</label>
 <input type="file" id="relais-image" name="image" accept="image/jpeg, image/png, image/gif" required multiple>
 <small>Jusqu’à 3 images. L’ordre compte, la première sera la principale.</small>
-<div id="image-preview-container" style="margin-top: 10px; display: flex; gap: 8px;">
+ <div id="image-preview-container" style="margin-top: 10px; display: flex; gap: 8px;">
    <!-- miniatures JS -->
 </div>
-            <div id="image-preview-container" style="margin-top: 10px;">
+            <div id="image-preview-wrapper" style="margin-top: 10px;">
                  <img id="image-preview" src="#" alt="Aperçu de l'image" style="max-width: 200px; max-height: 200px; display: none;"/>
                  <span id="no-image-text">Aucune image sélectionnée</span>
             </div>
@@ -308,7 +308,6 @@
         </div>
     </div>
 </section>
-<button onclick="document.getElementById('edit-relais-modal').style.display='flex'">TEST MODALE EDIT</button>
 
     </main>
 

--- a/js/auth-ui.js
+++ b/js/auth-ui.js
@@ -29,8 +29,8 @@ function updateUIForLoggedInUser(user) {
 // Met à jour l'UI du header pour un utilisateur déconnecté
 function updateUIForLoggedOutUser() {
     if (!authContainer) return;
-    authContainer.innerHTML = `<button id="google-signin-button" class="btn btn-primary">Connexion avec Google</button>`;
-    const googleSignInButton = document.getElementById('google-signin-button');
+    authContainer.innerHTML = `<button id="google-signin-button-header" class="btn btn-primary">Connexion avec Google</button>`;
+    const googleSignInButton = document.getElementById('google-signin-button-header');
     if (googleSignInButton) {
         googleSignInButton.addEventListener('click', signInWithGoogle); // Appel de la fonction importée
     }
@@ -38,7 +38,7 @@ function updateUIForLoggedOutUser() {
 
 // Attache l'écouteur initial (utile si l'utilisateur n'est pas connecté au chargement initial)
 function setupInitialAuthButton() {
-    const initialGoogleButton = document.getElementById('google-signin-button');
+    const initialGoogleButton = document.querySelector('#google-signin-button-login, #google-signin-button-header');
      // Attache seulement s'il existe ET si currentUser (importé depuis app.js ou passé en arg) est null.
      // Pour simplifier, on suppose ici que app.js gérera cet état initial.
      // OU on pourrait juste s'assurer que updateUIForLoggedOutUser le refait toujours.


### PR DESCRIPTION
## Summary
- rename duplicate google signin IDs to header and login versions
- rename extra image preview container to wrapper
- remove leftover test button
- update auth-ui script selectors

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684dcb7814fc8332b56b30a0000eb02a