### PR TITLE
Keep footer visible during login

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -101,7 +101,7 @@ main {
   display: flex;
   align-items: center;
   justify-content: center;
-  height: 100vh;
+  min-height: calc(100vh - 120px);
   background: linear-gradient(135deg, #eaf7f1, #f5fcfb);
   padding: 20px;
 }

--- a/js/auth-ui.js
+++ b/js/auth-ui.js
@@ -54,7 +54,6 @@ function showLoginScreen(message = "") {
     document.getElementById('loginScreen').style.display = 'flex';
     document.querySelector('main').style.display = 'none';
     document.querySelector('header').style.display = 'none';
-    document.querySelector('footer').style.display = 'none';
     const err = document.getElementById('login-error');
     if (err) {
         err.style.display = message ? 'block' : 'none';


### PR DESCRIPTION
## Summary
- modify `showLoginScreen` so the footer remains visible
- adjust `.login-screen` height so the page stays tidy with the footer showing

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684dd61a78488332b64048cf0fac1348