### PR TITLE
Update README with sign-in info

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 RelaisCSE est une application web qui facilite l'échange d'objets de seconde main entre salariés.
 Le projet repose sur des modules JavaScript et Firebase pour l'authentification et la gestion des données.
+La plupart du site, y compris le pied de page, n'apparaît qu'après connexion.
+
 
 ## Lancer le projet en local
 
@@ -20,4 +22,7 @@ Le projet repose sur des modules JavaScript et Firebase pour l'authentification 
 - Messagerie interne et gestion des favoris
 
 N'hésitez pas à améliorer le code ou l'interface selon vos besoins.
+## Dépannage
+
+Si la connexion échoue, vérifiez que `config/firebase-config.js` contient les informations correctes de votre projet Firebase.
 


### PR DESCRIPTION
## Summary
- mention that most of the site (and footer) show only after signing in
- add troubleshooting tip about verifying `config/firebase-config.js`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684dd61e2df48332a26205d964e63d7b